### PR TITLE
Refactored to use the new imageUrl from core

### DIFF
--- a/src/Flag.tsx
+++ b/src/Flag.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import './Flag.scss'
 
-import { isoToCountryCode } from 'flagpack-core'
+import { isoToCountryCode, imageUrl } from 'flagpack-core'
 
 interface Props {
   code: String,
@@ -41,7 +41,7 @@ class Flag extends React.PureComponent<Props, void> {
           ${hasBorderRadius ? 'border-radius' : ''}
           ${className}`.replace(/\s\s+/g, ' ').trim()
       }>
-        <img src={`https://raw.githubusercontent.com/Yummygum/flag-pack-core/master/svg/${size.toLowerCase()}/${isoToCountryCode(code).toUpperCase()}.svg?sanitize=true`}/>
+        <img src={imageUrl(isoToCountryCode(code).toUpperCase(), size.toLowerCase())}/>
       </div>
     )
   }


### PR DESCRIPTION
Following [my changes on flag-pack-core](https://github.com/Yummygum/flag-pack-core/pull/5), the code now uses the new `imageUrl()` function  to get the image URL instead of a hardcoded GitHub request.