### PR TITLE
fix(CLI): Use correct relative path for gatsby postinstall

### DIFF
--- a/cli/flagpack.js
+++ b/cli/flagpack.js
@@ -41,7 +41,7 @@ function copyFrameworkAware(framework, absolutePath) {
   let destination = path.resolve(projectRoot, './public/flags')
 
   if (framework === 'gatsby') {
-    destination = path.resolve(projectRoot, '/static/flags')
+    destination = path.resolve(projectRoot, './static/flags')
   }
 
   if (absolutePath) {


### PR DESCRIPTION
This pull request makes a minor correction to the destination path used when copying flag assets for Gatsby projects in the `copyFrameworkAware` function. The change ensures the path gets treated as a relative path, instead of an absolute path which caused the `postinstall` script to fail in Gatsby projects.

* Fixed the Gatsby-specific destination path in `copyFrameworkAware` to use `./static/flags` instead of `/static/flags` in `cli/flagpack.js`. 

Closes #83 

 <div id='description'>
<a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>

<ul>

<li>Fixes a bug in the CLI by correcting the destination path for flag assets in Gatsby projects.</li>

<li>Replaces an absolute path with a relative path to prevent the postinstall script from failing.</li>

<li>Ensures that the Gatsby-specific logic in the CLI behaves as expected.</li>

<li>Overall, the changes fix a bug in the CLI for Gatsby projects by updating the asset copying process, enhancing reliability.</li>

</ul>

</div>